### PR TITLE
Updated Import command to accommodate over-writing of data

### DIFF
--- a/docs/team/leegengyu.adoc
+++ b/docs/team/leegengyu.adoc
@@ -32,7 +32,7 @@ NSync is a desktop application with a command-line interface that helps students
 *** Contributed to forum discussions: #14, #27
 *** Reported bugs and suggestions for team T09-4 in the class: #129, #131, #133, #136, #138, #140, #141, #143
 
-** Minor Enhancement: Added the feature to *find the next immediate free time-slot*
+** Minor Enhancement: Added the feature to *find the next immediate free time-slot*.
 *** Allows the user to find the next immediate `free` time-slot for himself, and/or his contacts from the current time.
 
 == Contributions to the User Guide

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -28,8 +28,8 @@ public class ImportCommand extends Command {
     private final String personString;
 
     private static final String MESSAGE_SUCCESS = "Import successful";
+    private static final String MESSAGE_SUCCESS_OVERWRITE = "Import successful, user data is overwritten";
     private static final String MESSAGE_FAILED = "Failed to import";
-    private static final String MESSAGE_DUPLICATE = "Failed to import, duplicate person exist";
 
     public ImportCommand(String input) {
         requireNonNull(input);
@@ -38,8 +38,7 @@ public class ImportCommand extends Command {
 
     /**
      * Reads the input Base64 String and serialize a person object and add it into the addressbook
-     *
-     * @throws DuplicatePersonException if the person that the user is trying to add already exists
+     * overwrites user data if person already exists
      */
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
@@ -47,14 +46,16 @@ public class ImportCommand extends Command {
         requireNonNull(model);
         Person p = getSerializedPerson(personString);
 
-        try {
-            model.addPerson(p);
-        } catch (DuplicatePersonException e) {
-            throw new CommandException(MESSAGE_DUPLICATE);
+        String outputToUser = MESSAGE_SUCCESS;
+
+        if (model.hasPerson(p)) {
+            model.deletePerson(p);
+            outputToUser = MESSAGE_SUCCESS_OVERWRITE;
         }
 
+        model.addPerson(p);
         model.commitAddressBook();
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(outputToUser);
 
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -111,26 +111,17 @@ public class Person implements Serializable {
     }
 
     /**
-     * Returns true if both persons have the same identity and data fields.
-     * This defines a stronger notion of equality between two persons.
+     * Returns true if both persons have the same name.
      */
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
 
         if (!(other instanceof Person)) {
             return false;
         }
 
         Person otherPerson = (Person) other;
-        return otherPerson.getName().equals(getName())
-            && otherPerson.getPhone().equals(getPhone())
-            && otherPerson.getEmail().equals(getEmail())
-            && otherPerson.getAddress().equals(getAddress())
-            && otherPerson.getTags().equals(getTags())
-            && otherPerson.getEnrolledModules().equals(getEnrolledModules());
+        return otherPerson.getName().equals(getName());
     }
 
     @Override


### PR DESCRIPTION
Previously, `import` command will raise an exception saying "Duplicate entry exists" if there is an existing contact with the same name as that of the contact who is being imported.

Now, the imported person's details will over-write that of the current person's details if they have the same name (which is the unique identifier in our application).